### PR TITLE
Fix for histories and datasets with identical names

### DIFF
--- a/galaxy-fuse.py
+++ b/galaxy-fuse.py
@@ -65,11 +65,20 @@ def unesc_filename(fname):
 
     return re.sub(r'%(.)', unesc, fname)
 
+def parse_name_with_id(fname):
+    #1cd8e2f6b131e891
+    m = re.match(r"^(?P<name>.*)-(?P<id>[0-9a-f]{16})", fname)
+    if m is not None:
+        return (m.group('name'), m.group('id'))
+    else:
+        return (fname,'')
+
+
 class Context(LoggingMixIn, Operations):
     'Prototype FUSE to galaxy histories'
 
-    def __init__(self, api_key):
-        self.gi = galaxy.GalaxyInstance(url='http://127.0.0.1:80', key=api_key)
+    def __init__(self, server_addr, api_key):
+        self.gi = galaxy.GalaxyInstance(url=server_addr, key=api_key)
         self.datasets_cache = {}
         self.histories_cache = {'time':None, 'contents':None}
 
@@ -122,11 +131,17 @@ class Context(LoggingMixIn, Operations):
 
     # Find a specific history by name
     def _history(self,h_name):
-        h = filter(lambda x: x['name']==h_name, self._histories())
+        (fixed_name, hist_id) = parse_name_with_id(h_name)
+        h = filter(lambda x: x['name']==fixed_name, self._histories())
         if len(h)==0:
             raise FuseOSError(ENOENT)
         if len(h)>1:
-            print "Too many histories with that name"
+            h = filter(lambda x: x['id']==hist_id, self._histories())
+            if len(h)==0:
+                raise FuseOSError(ENOENT)
+            if len(h)>1:
+                print "Too many histories with identical names and IDs"
+            return h[0]
         return h[0]
 
     # Lookup all datasets in the specified history; cache
@@ -143,12 +158,18 @@ class Context(LoggingMixIn, Operations):
     def _dataset(self, kw):
         h = self._history(kw['h_name'])
         ds = self._datasets(h)
-        d = filter(lambda x: x['name']==kw['ds_name'], ds)
+        (d_name, d_id) = parse_name_with_id(kw['ds_name'])
+        d = filter(lambda x: x['name']==d_name, ds)
+
         if len(d)==0:
             raise FuseOSError(ENOENT)
         if len(d)>1:
-            print "Too many datasets with that name"
-            raise FuseOSError(ENOENT)
+            d = filter(lambda x: x['name']==d_name and x['id'] == d_id, ds)
+            if len(d)==0:
+                raise FuseOSError(ENOENT)
+            if len(d)>1:
+                print "Too many datasets with that name and ID"
+            return d[0]
         if 'file_name' not in d[0]:
             print "Unable to find file of dataset.  Have you set : expose_dataset_path = True"
             raise FuseOSError(ENOENT)
@@ -161,12 +182,39 @@ class Context(LoggingMixIn, Operations):
             return ['.', '..', 'histories']
         elif typ=='histories':
             hl = self._histories()
-            return ['.', '..'] + [esc_filename(h['name']) for h in hl]
+            # Count duplicates
+            hist_count = {}
+            for h in hl:
+                try:
+                    hist_count[h['name']] += 1
+                except:
+                    hist_count[h['name']] = 1
+            # Build up results manually
+            results = ['.', '..']
+            for h in hl:
+                if h['name'] in hist_count and hist_count[h['name']] > 1:
+                    results.append(esc_filename(h['name'] + '-' + h['id']))
+                else:
+                    results.append(esc_filename(h['name']))
+            return results
         elif typ=='datasets':
             h = self._history(kw['h_name'])
             ds = self._datasets(h)
             #print ds
-            return ['.', '..'] + [esc_filename(d['name']) for d in ds]
+            # Count duplicates
+            d_count = {}
+            for d in ds:
+                try:
+                    d_count[d['name']] += 1
+                except:
+                    d_count[d['name']] = 1
+            results = ['.', '..']
+            for d in ds:
+                if d['name'] in d_count and d_count[d['name']] > 1:
+                    results.append(esc_filename(d['name'] + '-' + d['id']))
+                else:
+                    results.append(esc_filename(d['name']))
+            return results
 
 
     # Disable unused operations:
@@ -182,14 +230,14 @@ class Context(LoggingMixIn, Operations):
 
 
 if __name__ == '__main__':
-    if len(argv) != 3:
-        print('usage: %s <mountpoint> <your_api_key>' % argv[0])
+    if len(argv) != 4:
+        print('usage: %s <mountpoint> <server> <your_api_key>' % argv[0])
         exit(1)
 
-    mountpoint, key = argv[1:3]
+    mountpoint, server, key = argv[1:4]
 
     # Create the directory if it does not exist
     if not os.path.exists(mountpoint):
         os.makedirs(mountpoint)
 
-    fuse = FUSE(Context(key), mountpoint, foreground=True, ro=True)
+    fuse = FUSE(Context(server, key), mountpoint, foreground=True, ro=True)


### PR DESCRIPTION
Access to histories and datasets with identical names previously failed with console logged error messages. This allows for that duplication by appending the history id to the history name, e.g.
- `Unnamed history-1cd8e2f6b131e891`
- `Unnamed history-ebfb8f50c6abde6d`

This can then be used to disambiguate between the two folders/files.

FYI: I'm working on support for read and write of datasets with any remote galaxy server, which is the reason for adding the server parameter. While that's not necessary in your case, it would work if you're on a shared filesystem and (for some crazy reason) had access to all of galaxy's datasets.
